### PR TITLE
DATADOG-692: Update log4j version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.5</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Update all log4j version references to 2.16.0 (the new safest)